### PR TITLE
Replace enforce_2fa with enforce_tfa due to changes in directus codebase

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -173,14 +173,14 @@ export async function importRoles(rolesService: ItemsService) {
     const roles = fromYaml(yamlInput) as Array<StoredRole>
 
     const rolesToImport: Array<Role> = roles.map((block) => {
-        const { id, name, icon, description, enforce_2fa, external_id, ip_whitelist, app_access, admin_access } = block
+        const { id, name, icon, description, enforce_tfa, external_id, ip_whitelist, app_access, admin_access } = block
 
         return {
             id,
             name,
             icon: icon ?? 'supervised_user_circle',
             description: description ?? '',
-            enforce_2fa: enforce_2fa ?? false,
+            enforce_tfa: enforce_tfa ?? false,
             external_id: external_id ?? null,
             ip_whitelist: ip_whitelist ?? [],
             app_access: app_access ?? false,
@@ -194,7 +194,7 @@ export async function importRoles(rolesService: ItemsService) {
 export async function exportRoles(rolesService: ItemsService) {
     const rows = await rolesService.readByQuery({
         limit: -1,
-        fields: ['id', 'name', 'icon', 'description', 'enforce_2fa', 'external_id', 'ip_whitelist', 'app_access', 'admin_access'],
+        fields: ['id', 'name', 'icon', 'description', 'enforce_tfa', 'external_id', 'ip_whitelist', 'app_access', 'admin_access'],
     }) as Role[]
 
     const roles: Array<StoredRole> = rows.map((row) => {


### PR DESCRIPTION
Hi, looks like directus changed **_2fa_** prop/field with **_tfa_** in their codebase.
Current code won't build with success status due to use of enforce_2fa prop, which should be enforce_tfa instead.
I've added a link to the [pr, when the change seems to be made here](https://github.com/directus/directus/pull/7805/files/d74a46e40d19881525376530a6584699e657e29d#diff-c2ab1803c892ee6ce5115c44de32aaf61ffbec1951fa6dd0f71f9b75b17bf046) -> [_packages/shared/src/types/users.ts_](https://github.com/directus/directus/blob/d74a46e40d19881525376530a6584699e657e29d/packages/shared/src/types/users.ts#L6).

I've just switched the 2fa prop name to tfa, which results in a successful build and should take tfa into account now.