### PR TITLE
Sort actions before exporting to have predictable order

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/knex": "^0.16.1",
     "@types/lodash": "^4.14.191",
+    "@types/lodash-es": "^4.17.7",
     "@types/node": "^20.1.5",
     "typescript": "^5.0.4"
   },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -111,7 +111,9 @@ export async function exportPermissions(collection: string, permissionsService: 
 
     // Find matching permissions to group roles into
     const uniquePerms: Array<[StoredPermission, Array<string | null>]> = []
-    rows.forEach(row => {
+	rows.sort(
+		(rowA, rowB) => rowA.action.localeCompare(rowB.action)
+	).forEach((row) => {
         const { role, action, permissions, validation, presets, fields } = row;
         const perm: StoredPermission = {
             action

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -92,7 +92,7 @@ export async function importPermissions(collection: string, permissionsService: 
             fields: ['id']
         }, { emitEvents: false })
 
-        if (exists?.length) {
+        if (exists?.length && exists[0]?.id) {
             await permissionsService.updateOne(exists[0].id, permission, { emitEvents: false })
         } else {
             await permissionsService.createOne(permission, { emitEvents: false })
@@ -155,10 +155,15 @@ export async function exportPermissions(collection: string, permissionsService: 
 
     const yamlFile = path.join(permissionsPath, `${collection}.yaml`)
     if (! yamlOutput.startsWith('[]')) {
-        yamlOutput = yamlOutput.replaceAll('- action', '\n- action')
-        await fse.writeFile(yamlFile, yamlOutput, 'utf8');
+        yamlOutput = yamlOutput.replace(/- action/g, '\n- action')
+        await fse.writeFile(yamlFile, yamlOutput, 'utf8').catch(console.error);
     } else {
-        await fse.remove(yamlFile)
+		const filepathDir = path.dirname(yamlFile)
+		await fse.readdir(filepathDir).then((files) => {
+			if (files.find((file) => file === `${collection}.yaml`)) {
+				return fse.remove(yamlFile)
+			}
+		}).catch(console.error)
     }
 }
 
@@ -223,7 +228,7 @@ export async function exportRoles(rolesService: ItemsService) {
     })
 
     if (! yamlOutput.startsWith('[]')) {
-        yamlOutput = yamlOutput.replaceAll('- id', '\n- id')
+		yamlOutput = yamlOutput.replace(/- id/g, '\n- id')
 
         await fse.writeFile(rolesFile, yamlOutput, 'utf8');
     } else {


### PR DESCRIPTION
### Reason
When saving/exporting permissions then the order in which the actions are returned from `directus` seem to be not predictable.
After `sorting` the permission `actions` `by alphabet`, the order is predictable due to alphabetical sort.

For example, when looking through the config files, searching for a permission, the logic behind finding an action will be easier - as the order will always be `create`, `delete`, `read`, `share`, `update` (instead of random order or either initial db row order)

#### Other additions to PR
- Using regex w `.replace()` instead of `.replaceAll()` to allow more backwards compatibility
- Checking for array element id before reading it `a[0].id`
- Checking if file exists before removal to allow other-cased files not to be removed too 
  - remove `Aa.txt` and keep `aa.txt`, if `Aa.txt` doesn't exist, then won't try to remove it